### PR TITLE
Fix state->max_msg being read and written to within same statement.

### DIFF
--- a/protobuf-c-text/parse.re
+++ b/protobuf-c-text/parse.re
@@ -722,9 +722,10 @@ state_assignment(State *state, Token *t)
         if (state->current_msg == state->max_msg) {
           ProtobufCMessage **tmp_msgs;
 
+          state->max_msg += 10;
           tmp_msgs = local_realloc(
-              state->msgs, (state->max_msg) * sizeof(ProtobufCMessage *),
-              (state->max_msg += 10) * sizeof(ProtobufCMessage *),
+              state->msgs, (state->current_msg) * sizeof(ProtobufCMessage *),
+              (state->max_msg) * sizeof(ProtobufCMessage *),
               state->allocator);
           if (!tmp_msgs) {
             return state_error(state, t, "Malloc failure.");


### PR DESCRIPTION
state->max_msg is read and changed in the same function call to local_realloc(); this might cause trouble depending on how (i.e. in which order) the compiler evaluates the parameters.
