### PR TITLE
Fix wrong integer en- and decoding in protobuf-c-text library.

### DIFF
--- a/protobuf-c-text/generate.c
+++ b/protobuf-c-text/generate.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <protobuf-c/protobuf-c.h>
 #include "protobuf-c-text.h"
 #include "protobuf-c-util.h"
@@ -228,14 +229,14 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
           for (j = 0; j < quantifier_offset; j++) {
             rs_append(rs, level + strlen(f[i].name) + 20,
                 allocator,
-                "%*s%s: %u\n",
+                "%*s%s: %" PRIu32 "\n",
                 level, "", f[i].name,
                 STRUCT_MEMBER(uint32_t *, m, f[i].offset)[j]);
           }
         } else {
           rs_append(rs, level + strlen(f[i].name) + 20,
               allocator,
-              "%*s%s: %u\n",
+              "%*s%s: %" PRIu32 "\n",
               level, "", f[i].name,
               STRUCT_MEMBER(uint32_t, m, f[i].offset));
         }
@@ -247,14 +248,14 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
           for (j = 0; j < quantifier_offset; j++) {
             rs_append(rs, level + strlen(f[i].name) + 20,
                 allocator,
-                "%*s%s: %d\n",
+                "%*s%s: %" PRId32 "\n",
                 level, "", f[i].name,
                 STRUCT_MEMBER(int32_t *, m, f[i].offset)[j]);
           }
         } else {
           rs_append(rs, level + strlen(f[i].name) + 20,
               allocator,
-              "%*s%s: %d\n",
+              "%*s%s: %" PRId32 "\n",
               level, "", f[i].name,
               STRUCT_MEMBER(int32_t, m, f[i].offset));
         }
@@ -265,14 +266,14 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
           for (j = 0; j < quantifier_offset; j++) {
             rs_append(rs, level + strlen(f[i].name) + 20,
                 allocator,
-                "%*s%s: %lu\n",
+                "%*s%s: %" PRIu64 "\n",
                 level, "", f[i].name,
                 STRUCT_MEMBER(uint64_t *, m, f[i].offset)[j]);
           }
         } else {
           rs_append(rs, level + strlen(f[i].name) + 20,
               allocator,
-              "%*s%s: %lu\n",
+              "%*s%s: %" PRIu64 "\n",
               level, "", f[i].name,
               STRUCT_MEMBER(uint64_t, m, f[i].offset));
         }
@@ -284,14 +285,14 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
           for (j = 0; j < quantifier_offset; j++) {
             rs_append(rs, level + strlen(f[i].name) + 20,
                 allocator,
-                "%*s%s: %ld\n",
+                "%*s%s: %" PRId64 "\n",
                 level, "", f[i].name,
                 STRUCT_MEMBER(int64_t *, m, f[i].offset)[j]);
           }
         } else {
           rs_append(rs, level + strlen(f[i].name) + 20,
               allocator,
-              "%*s%s: %ld\n",
+              "%*s%s: %" PRId64 "\n",
               level, "", f[i].name,
               STRUCT_MEMBER(int64_t, m, f[i].offset));
         }

--- a/protobuf-c-text/generate.c
+++ b/protobuf-c-text/generate.c
@@ -222,7 +222,6 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
     quantifier_offset = STRUCT_MEMBER(size_t, m, f[i].quantifier_offset);
     /* Field exists and has data, dump it. */
     switch (f[i].type) {
-      case PROTOBUF_C_TYPE_INT32:
       case PROTOBUF_C_TYPE_UINT32:
       case PROTOBUF_C_TYPE_FIXED32:
         if (f[i].label == PROTOBUF_C_LABEL_REPEATED) {
@@ -241,6 +240,7 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
               STRUCT_MEMBER(uint32_t, m, f[i].offset));
         }
         break;
+      case PROTOBUF_C_TYPE_INT32:
       case PROTOBUF_C_TYPE_SINT32:
       case PROTOBUF_C_TYPE_SFIXED32:
         if (f[i].label == PROTOBUF_C_LABEL_REPEATED) {
@@ -259,7 +259,6 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
               STRUCT_MEMBER(int32_t, m, f[i].offset));
         }
         break;
-      case PROTOBUF_C_TYPE_INT64:
       case PROTOBUF_C_TYPE_UINT64:
       case PROTOBUF_C_TYPE_FIXED64:
         if (f[i].label == PROTOBUF_C_LABEL_REPEATED) {
@@ -278,6 +277,7 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
               STRUCT_MEMBER(uint64_t, m, f[i].offset));
         }
         break;
+      case PROTOBUF_C_TYPE_INT64:
       case PROTOBUF_C_TYPE_SINT64:
       case PROTOBUF_C_TYPE_SFIXED64:
         if (f[i].label == PROTOBUF_C_LABEL_REPEATED) {

--- a/protobuf-c-text/parse.re
+++ b/protobuf-c-text/parse.re
@@ -944,7 +944,6 @@ state_value(State *state, Token *t)
 
     case TOK_NUMBER:
       switch (state->field->type) {
-        case PROTOBUF_C_TYPE_INT32:
         case PROTOBUF_C_TYPE_UINT32:
         case PROTOBUF_C_TYPE_FIXED32:
           val = strtoul(t->number, &end, 10);
@@ -975,6 +974,7 @@ state_value(State *state, Token *t)
           }
           break;
 
+        case PROTOBUF_C_TYPE_INT32:
         case PROTOBUF_C_TYPE_SINT32:
         case PROTOBUF_C_TYPE_SFIXED32:
           val = strtol(t->number, &end, 10);
@@ -1005,7 +1005,6 @@ state_value(State *state, Token *t)
           }
           break;
 
-        case PROTOBUF_C_TYPE_INT64:
         case PROTOBUF_C_TYPE_UINT64:
         case PROTOBUF_C_TYPE_FIXED64:
           val = strtoull(t->number, &end, 10);
@@ -1036,6 +1035,7 @@ state_value(State *state, Token *t)
           }
           break;
 
+        case PROTOBUF_C_TYPE_INT64:
         case PROTOBUF_C_TYPE_SINT64:
         case PROTOBUF_C_TYPE_SFIXED64:
           val = strtoll(t->number, &end, 10);


### PR DESCRIPTION
1. int{32,64} should be treated as signed integers (see https://developers.google.com/protocol-buffers/docs/proto#scalar)
2. [u]int64 are [unsigned] long long integers on 32 bit platforms. The second patch uses inttypes.h macros for a compatible way to printf these integers, but this probably needs C99 where inttypes.h was officially introduced.