### PR TITLE
Fixed memory leak in parse.re.

### DIFF
--- a/protobuf-c-text/parse.re
+++ b/protobuf-c-text/parse.re
@@ -166,6 +166,7 @@ token_free(Token *t, ProtobufCAllocator *allocator)
       break;
     case TOK_QUOTED:
       PBC_FREE(t->qs->data);
+      PBC_FREE(t->qs);
       break;
     case TOK_NUMBER:
       PBC_FREE(t->number);


### PR DESCRIPTION
Added missing `PBC_FREE` (in token_free) for `ProtobufCBinaryData` struct allocated in `unesc_str`.