### PR TITLE
esc_str: escape with octal as unsigned (buffer overflow otherwise)

### DIFF
--- a/protobuf-c-text/generate.c
+++ b/protobuf-c-text/generate.c
@@ -148,7 +148,7 @@ esc_str(char *src, int len, ProtobufCAllocator *allocator)
       /* Escape with octal if !isprint. */
       default:
         if (!isprint(src[i])) {
-          dst_len += sprintf(dst + dst_len, "\\%03o", src[i]);
+          dst_len += sprintf(dst + dst_len, "\\%03o", (unsigned char)src[i]);
         } else {
           dst[dst_len++] = src[i];
         }


### PR DESCRIPTION
Signed-off-by: Serge Ziryukin <ftrvxmtrx@gmail.com>