### PR TITLE
Added support for oneof fields

### DIFF
--- a/protobuf-c-text/generate.c
+++ b/protobuf-c-text/generate.c
@@ -193,6 +193,14 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
       return;
     }
 
+    if (0 != (f[i].flags & PROTOBUF_C_FIELD_FLAG_ONEOF) &&
+        f[i].id != STRUCT_MEMBER(uint32_t, m, f[i].quantifier_offset))
+    {
+      /* This is not the selected oneof, skip it */
+      continue;
+    }
+
+
     /* Decide if something needs to be done for this field. */
     switch (f[i].label) {
       case PROTOBUF_C_LABEL_OPTIONAL:

--- a/protobuf-c-text/parse.re
+++ b/protobuf-c-text/parse.re
@@ -741,6 +741,10 @@ state_assignment(State *state, Token *t)
         } else {
           STRUCT_MEMBER(ProtobufCMessage *, msg, state->field->offset)
             = state->msgs[state->current_msg];
+          /* Set the field as the assigned oneof */
+          if (0 != (state->field->flags & PROTOBUF_C_FIELD_FLAG_ONEOF)) {
+            STRUCT_MEMBER(uint32_t, msg, state->field->quantifier_offset) = state->field->id;
+          }
           return STATE_OPEN;
         }
 
@@ -789,6 +793,12 @@ state_value(State *state, Token *t)
             state->field->quantifier_offset) = 1;
     }
   }
+
+  /* Set the field as the assigned oneof */
+  if (0 != (state->field->flags & PROTOBUF_C_FIELD_FLAG_ONEOF)) {
+    STRUCT_MEMBER(uint32_t, msg, state->field->quantifier_offset) = state->field->id;
+  }
+
   switch (t->id) {
     case TOK_BAREWORD:
       if (state->field->type == PROTOBUF_C_TYPE_ENUM) {


### PR DESCRIPTION
I was in need of support for `oneof` fields (https://protobuf.dev/programming-guides/proto2/#oneof) and created this PR which adds support for both generating and parsing of `oneof` fields.

